### PR TITLE
Refactored ITeleporter into ITeleporter, AbstractTeleporter, and AbstractPOITTeleporter

### DIFF
--- a/patches/minecraft/net/minecraft/world/Teleporter.java.patch
+++ b/patches/minecraft/net/minecraft/world/Teleporter.java.patch
@@ -5,7 +5,7 @@
  import net.minecraft.world.server.TicketType;
  
 -public class Teleporter {
-+public class Teleporter implements net.minecraftforge.common.util.ITeleporter {
++public class Teleporter extends net.minecraftforge.common.util.AbstractPOITTeleporter {
     protected final ServerWorld field_85192_a;
  
     public Teleporter(ServerWorld p_i1963_1_) {
@@ -23,3 +23,11 @@
        }, p_242957_1_, i, PointOfInterestManager.Status.ANY).sorted(Comparator.<PointOfInterest>comparingDouble((p_242954_1_) -> {
           return p_242954_1_.func_218261_f().func_177951_i(p_242957_1_);
        }).thenComparingInt((p_242959_0_) -> {
+@@ -157,4 +157,7 @@
+ 
+       return true;
+    }
++   @Override public boolean isVanilla() { return true; }
++   @Override public PointOfInterestType getPortalPOI() { return PointOfInterestType.field_226358_u_; }
++   @Override public Optional<TeleportationRepositioner.Result> createAndGetPortal(ServerWorld fromWorld, ServerWorld toWorld, net.minecraft.entity.Entity entity) { return Optional.empty(); }
+ }

--- a/src/main/java/net/minecraftforge/common/util/AbstractPOITTeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/AbstractPOITTeleporter.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.common.util;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.TeleportationRepositioner;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.village.PointOfInterestType;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.Teleporter;
+import net.minecraft.world.server.ServerWorld;
+
+import java.util.Optional;
+
+public abstract class AbstractPOITTeleporter extends AbstractTeleporter
+{
+    @Override
+    public Optional<TeleportationRepositioner.Result> findPortal(ServerWorld fromWorld, ServerWorld toWorld,
+            Entity entity)
+    {
+        return new Teleporter(toWorld).func_242957_a(new BlockPos(entity.getPositionVec()),
+                DimensionType.func_242715_a(fromWorld.func_230315_m_(), toWorld.func_230315_m_()) < 1,
+                this.getPortalPOI());
+    }
+
+    abstract public PointOfInterestType getPortalPOI();
+}

--- a/src/main/java/net/minecraftforge/common/util/AbstractTeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/AbstractTeleporter.java
@@ -1,0 +1,64 @@
+package net.minecraftforge.common.util;
+
+import net.minecraft.block.PortalInfo;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Direction;
+import net.minecraft.util.TeleportationRepositioner;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.vector.Vector3d;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.World;
+import net.minecraft.world.border.WorldBorder;
+import net.minecraft.world.server.ServerWorld;
+
+import java.util.function.Function;
+
+public abstract class AbstractTeleporter implements ITeleporter
+{
+    /**
+     * Scales the given {@link BlockPos} based on the {@link World}s passed in.
+     */
+    public static BlockPos getScaledPos(World fromWorld, World toWorld, BlockPos originalPos)
+    {
+        WorldBorder worldborder = toWorld.getWorldBorder();
+        double minX = Math.max(-2.9999872E7D, worldborder.minX() + 16.0D);
+        double minZ = Math.max(-2.9999872E7D, worldborder.minZ() + 16.0D);
+        double maxX = Math.min(2.9999872E7D, worldborder.maxX() - 16.0D);
+        double maxZ = Math.min(2.9999872E7D, worldborder.maxZ() - 16.0D);
+        double dimensionScaling = DimensionType.func_242715_a(fromWorld.func_230315_m_(), toWorld.func_230315_m_());
+        return new BlockPos(MathHelper.clamp(originalPos.getX() * dimensionScaling, minX, maxX), originalPos.getY(),
+                MathHelper.clamp(originalPos.getZ() * dimensionScaling, minZ, maxZ));
+    }
+
+    /**
+     * An overload of {@link ITeleporter#getPortalInfo} that takes the entity being teleported as well as the
+     * destination world to create a complete {@link PortalInfo}.
+     */
+    public static PortalInfo getPortalInfo(TeleportationRepositioner.Result tpResult, Entity entity,
+            ServerWorld destWorld)
+    {
+        Direction.Axis axis1 = Direction.Axis.X;
+        Vector3d vector3d = new Vector3d(0.5D, 0.0D, 0.0D);
+        return net.minecraft.block.PortalSize.func_242963_a(destWorld, tpResult, axis1, vector3d,
+                entity.getSize(entity.getPose()), entity.getMotion(), entity.rotationYaw, entity.rotationPitch);
+    }
+
+    @Override
+    public Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw,
+            Function<Boolean, Entity> repositionEntity)
+    {
+        return repositionEntity.apply(true);
+    }
+
+    /**
+     * A default implementation of {@link ITeleporter#getPortalInfo(TeleportationRepositioner.Result)} that sets the yaw and pitch to 0.
+     * <p>
+     * To maintain the yaw and pitch of the original entity, see {@link AbstractTeleporter#getPortalInfo(TeleportationRepositioner.Result, Entity, ServerWorld)}.
+     */
+    @Override public PortalInfo getPortalInfo(TeleportationRepositioner.Result tpResult)
+    {
+        return new PortalInfo(new Vector3d(tpResult.field_243679_a.getX(), tpResult.field_243679_a.getY(),
+                tpResult.field_243679_a.getZ()), Vector3d.ZERO, 0, 0);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -25,13 +25,9 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.util.TeleportationRepositioner;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3d;
-import net.minecraft.village.PointOfInterestType;
 import net.minecraft.world.DimensionType;
 import net.minecraft.world.Teleporter;
-import net.minecraft.world.World;
-import net.minecraft.world.border.WorldBorder;
 import net.minecraft.world.server.ServerWorld;
 
 import java.util.Optional;
@@ -39,78 +35,56 @@ import java.util.function.Function;
 
 /**
  * Interface for handling the placement of entities during dimension change.
- *
+ * <p>
  * An implementation of this interface can be used to place the entity
  * in a safe location, or generate a return portal, for instance.
- *
+ * <p>
  * See the {@link net.minecraft.world.Teleporter} class, which has
  * been patched to implement this interface, for a vanilla example.
  */
-public interface ITeleporter {
-
+public interface ITeleporter
+{
     /**
      * Called to handle placing the entity in the new world.
-     *
+     * <p>
      * The initial position of the entity will be its
      * position in the origin world, multiplied horizontally
      * by the computed cross-dimensional movement factor.
-     *
+     * <p>
      * Note that the supplied entity has not yet been spawned
      * in the destination world at the time.
      *
-     * @param entity           the entity to be placed
-     * @param currentWorld     the entity's origin
-     * @param destWorld        the entity's destination
-     * @param yaw              the suggested yaw value to apply
+     * @param entity the entity to be placed
+     * @param currentWorld the entity's origin
+     * @param destWorld the entity's destination
+     * @param yaw the suggested yaw value to apply
      * @param repositionEntity a function to reposition the entity, which returns the new entity in the new dimension. This is the vanilla implementation of the dimension travel logic. If the supplied boolean is true, it is attempted to spawn a new portal.
+     *
      * @return the entity in the new World. Vanilla creates for most {@link Entity}s a new instance and copy the data. But <b>you are not allowed</b> to create a new instance for {@link PlayerEntity}s! Move the player and update its state, see {@link ServerPlayerEntity#changeDimension(net.minecraft.world.server.ServerWorld, ITeleporter)}
      */
-    default Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity) {
-       return repositionEntity.apply(true);
-    }
+    Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity);
 
-    // States if this teleporter is the vanilla instance
+    /**
+     * Is this teleporter the vanilla instance.
+     */
     default boolean isVanilla()
     {
-        return getClass() == Teleporter.class;
+        return false;
     }
 
-    // Replicated from the vanilla code for interface implementation. Return an empty optional if no portal was found.
-    default Optional<TeleportationRepositioner.Result> findPortal(ServerWorld fromWorld, ServerWorld toWorld,
-            Entity entity)
-    {
-        return new Teleporter(toWorld).func_242957_a(new BlockPos(entity.getPositionVec()),
-                DimensionType.func_242715_a(fromWorld.func_230315_m_(), toWorld.func_230315_m_()) < 1,
-                this.getPortalPOI());
-    }
+    /**
+     * Finds a portal to teleport to and creates a {@link TeleportationRepositioner.Result} for it.
+     * Return an empty {@link Optional} if no portal was found.
+     */
+    Optional<TeleportationRepositioner.Result> findPortal(ServerWorld fromWorld, ServerWorld toWorld, Entity entity);
 
-    // Creates a portal if one doesn't exist and returns the result. Default does nothing so you'll need to implement it for your portal.
-    default Optional<TeleportationRepositioner.Result> createAndGetPortal(ServerWorld fromWorld, ServerWorld toWorld, Entity entity)
-    {
-        return Optional.empty();
-    }
+    /**
+     * Creates a portal if one doesn't exist and returns the {@link TeleportationRepositioner.Result Result}.
+     */
+    Optional<TeleportationRepositioner.Result> createAndGetPortal(ServerWorld fromWorld, ServerWorld toWorld, Entity entity);
 
-    // Returns the portal info for the result. Default returns the tpResult position and zero values for everything else.
-    default PortalInfo getPortalInfo(TeleportationRepositioner.Result tpResult)
-    {
-        return new PortalInfo(new Vector3d(tpResult.field_243679_a.getX(), tpResult.field_243679_a.getY(), tpResult.field_243679_a.getZ()), Vector3d.ZERO, 0, 0);
-    }
-    
-    // Scales the given blockpos based on the worlds passed in.
-    default BlockPos getScaledPos(World fromWorld, World toWorld, BlockPos originalPos)
-    {
-    	WorldBorder worldborder = toWorld.getWorldBorder();
-        double minX = Math.max(-2.9999872E7D, worldborder.minX() + 16.0D);
-        double minZ = Math.max(-2.9999872E7D, worldborder.minZ() + 16.0D);
-        double maxX = Math.min(2.9999872E7D, worldborder.maxX() - 16.0D);
-        double maxZ = Math.min(2.9999872E7D, worldborder.maxZ() - 16.0D);
-        double dimensionScaling = DimensionType.func_242715_a(fromWorld.func_230315_m_(), toWorld.func_230315_m_());
-        return new BlockPos(MathHelper.clamp(originalPos.getX() * dimensionScaling, minX, maxX), originalPos.getY(), MathHelper.clamp(originalPos.getZ() * dimensionScaling, minZ, maxZ));
-    }
-
-    // Returns the point of interest type for teleporter to look for.
-    default PointOfInterestType getPortalPOI()
-    {
-    	return PointOfInterestType.NETHER_PORTAL;
-    }
+    /**
+     * Returns the {@link PortalInfo} for the {@link TeleportationRepositioner.Result Result}.
+     */
+    PortalInfo getPortalInfo(TeleportationRepositioner.Result tpResult);
 }

--- a/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandSetDimension.java
@@ -25,9 +25,11 @@ import net.minecraft.command.arguments.BlockPosArgument;
 import net.minecraft.command.arguments.DimensionArgument;
 import net.minecraft.command.arguments.EntityArgument;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.TeleportationRepositioner;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.util.AbstractTeleporter;
 import net.minecraftforge.common.util.ITeleporter;
 
 import com.mojang.brigadier.builder.ArgumentBuilder;
@@ -36,6 +38,7 @@ import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.function.Function;
 
 public class CommandSetDimension
@@ -66,7 +69,7 @@ public class CommandSetDimension
         //    throw INVALID_DIMENSION.create(dim);
 
         entities.stream().filter(e -> e.world == dim).forEach(e -> sender.sendFeedback(new TranslationTextComponent("commands.forge.setdim.invalid.nochange", e.getDisplayName().getString(), dim), true));
-        entities.stream().filter(e -> e.world != dim).forEach(e ->  e.changeDimension(dim , new ITeleporter()
+        entities.stream().filter(e -> e.world != dim).forEach(e ->  e.changeDimension(dim , new AbstractTeleporter()
         {
             @Override
             public Entity placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw, Function<Boolean, Entity> repositionEntity)
@@ -74,6 +77,20 @@ public class CommandSetDimension
                 Entity repositionedEntity = repositionEntity.apply(false);
                 repositionedEntity.setPositionAndUpdate(pos.getX(), pos.getY(), pos.getZ());
                 return repositionedEntity;
+            }
+
+            @Override
+            public Optional<TeleportationRepositioner.Result> findPortal(ServerWorld fromWorld, ServerWorld toWorld,
+                    Entity entity)
+            {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<TeleportationRepositioner.Result> createAndGetPortal(ServerWorld fromWorld,
+                    ServerWorld toWorld, Entity entity)
+            {
+                return Optional.empty();
             }
         }));
 


### PR DESCRIPTION
One problem I came across when working with the `ITeleporter` changes was that if I overrode one of the default methods, I couldn't use `super` to use the default implementation. This resolves that problem by moving all the methods that could be overriden into AbstractTeleporter and AbstractPOITTeleporter, depending on if the provided default implementation is specific to POIT based teleporters or not. This also makes it clearer which methods modded teleporters need to override depending on what they want their teleporter to do.

This also includes some javadoc changes and code simplification, as well as a new method for a more complete `PortalInfo` based on vanilla code.